### PR TITLE
Porting to Windows [x64 only]

### DIFF
--- a/Samples/Sample.csproj
+++ b/Samples/Sample.csproj
@@ -17,7 +17,7 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <ConsolePause>false</ConsolePause>
     <EnvironmentVariables>
       <EnvironmentVariables>
@@ -35,6 +35,25 @@
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
     <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <Optimize>true</Optimize>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Samples/sample.cs
+++ b/Samples/sample.cs
@@ -1,17 +1,15 @@
-using System.Threading;
-using System.Runtime.InteropServices;
+using System;
 using Urho;
 
 class Demo {
 	
 	static void Main ()
-	{
-		var c = new Context ();
-		//new Sample (c).Run ();
-		//new _01_HelloWorld (c).Run ();
-		//new _04_StaticScene (c).Run ();
-		//new _05_AnimatingScene (c).Run ();
-		new _23_Water(c).Run ();
-	}
+    {
+        var c = new Context ();
+		//var code = new _01_HelloWorld(c).Run ();
+        var code = new _23_Water(c).Run();
+        Console.WriteLine($"Exit code: {code}. Press any key to exit...");
+	    Console.ReadKey();
+    }
 }
 

--- a/Urho.sln
+++ b/Urho.sln
@@ -10,24 +10,34 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Debug|x64.Build.0 = Debug|Any CPU
 		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Debug|x86.Build.0 = Debug|Any CPU
 		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Release|x64.ActiveCfg = Release|Any CPU
+		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Release|x64.Build.0 = Release|Any CPU
 		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Release|x86.ActiveCfg = Release|Any CPU
 		{641886DB-2C6C-4D33-88DA-97BEC0EC5F86}.Release|x86.Build.0 = Release|Any CPU
 		{6D118A78-A002-4B95-8E4E-0434809C28E3}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{6D118A78-A002-4B95-8E4E-0434809C28E3}.Debug|Any CPU.Build.0 = Debug|x86
+		{6D118A78-A002-4B95-8E4E-0434809C28E3}.Debug|x64.ActiveCfg = Debug|x64
+		{6D118A78-A002-4B95-8E4E-0434809C28E3}.Debug|x64.Build.0 = Debug|x64
 		{6D118A78-A002-4B95-8E4E-0434809C28E3}.Debug|x86.ActiveCfg = Debug|x86
 		{6D118A78-A002-4B95-8E4E-0434809C28E3}.Debug|x86.Build.0 = Debug|x86
 		{6D118A78-A002-4B95-8E4E-0434809C28E3}.Release|Any CPU.ActiveCfg = Release|x86
+		{6D118A78-A002-4B95-8E4E-0434809C28E3}.Release|x64.ActiveCfg = Release|x64
+		{6D118A78-A002-4B95-8E4E-0434809C28E3}.Release|x64.Build.0 = Release|x64
 		{6D118A78-A002-4B95-8E4E-0434809C28E3}.Release|x86.ActiveCfg = Release|x86
 		{6D118A78-A002-4B95-8E4E-0434809C28E3}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/bindings/AllUrho.h
+++ b/bindings/AllUrho.h
@@ -1,5 +1,5 @@
 #ifdef _MSC_VER
-#define DllExport __stdcall__   __declspec( dllexport )
+#define DllExport __declspec( dllexport )
 #else
 #define DllExport
 #endif

--- a/bindings/parse.pl
+++ b/bindings/parse.pl
@@ -81,7 +81,7 @@ print CS "// Hash Getters\n";
 print CS "internal class UrhoHash {\n";
 foreach $pc (keys %hashgetters){
     $en = $hashgetters{$pc};
-    print CPP "int urho_hash_get_$pc ()\n{\n";
+    print CPP "DllExport int urho_hash_get_$pc ()\n{\n";
     print CPP "\treturn Urho3D::$en::$pc.Value ();\n}\n\n";
     print CS "        [DllImport(\"mono-urho\")]\n";
     print CS "        extern static int urho_hash_get_$pc ();\n";

--- a/bindings/src/ApplicationProxy.h
+++ b/bindings/src/ApplicationProxy.h
@@ -39,7 +39,7 @@ private:
 };
 
 extern "C" {
-void *
+DllExport void *
 ApplicationProxy_ApplicationProxy (Urho3D::Context *context, callback_t setup, callback_t start, callback_t stop);
 
 }

--- a/bindings/src/glue.cpp
+++ b/bindings/src/glue.cpp
@@ -129,7 +129,7 @@ extern "C" {
 	}
 
 	DllExport
-	uint Controls_GetButtons (Controls *controls)
+	unsigned Controls_GetButtons (Controls *controls)
 	{
 		return controls->buttons_;
 	}


### PR DESCRIPTION
changes to to be able to run Urho3d C# on windows. x64 only. In case to be able to run on 32bit as well the CallingConvention = Cdecl should be applied to all [DllImport("mono-urho")] attributes.
