### PR TITLE
[Build] Properly detect OS when on Mac.

### DIFF
--- a/MakeAndroid
+++ b/MakeAndroid
@@ -9,7 +9,7 @@ BUILD_TYPE=Release
 OUTPUT_DIR=Bin/Android/$(ABI)
 URHO3D_SRC_DIR=Urho3D/Source
 URHO3D_ANDROID_DIR=Urho3D/Urho3D_Android/$(ABI)
-
+OS=$(shell uname)
 
 ifeq ($(OS), Darwin)
 PREBUILT_DIR=darwin-x86_64


### PR DESCRIPTION
The variable is not automatically set. Insert an uname call that sets
the OS name.

This has been verified by echo-ing the contents of the .VARIABLES
variable via make.

This fixes the Android build on Mac for me.
