### PR TITLE
[disposable] Add IDisposable implementation to Subscription

### DIFF
--- a/Bindings/Portable/Runtime/Subscription.cs
+++ b/Bindings/Portable/Runtime/Subscription.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Urho
 {
-	public class Subscription {
+	public class Subscription : IDisposable {
 		internal GCHandle gch;
 		internal IntPtr   UnmanagedProxy;
 
@@ -15,6 +15,11 @@ namespace Urho
 
 		[DllImport (Consts.NativeImport, CallingConvention=CallingConvention.Cdecl)]
 		extern static void urho_unsubscribe (IntPtr notificationProxy);
+		
+		public void Dispose()
+		{
+			Unsubscribe ();
+		}
 		
 		public void Unsubscribe ()
 		{

--- a/Docs/Urho/Subscription.xml
+++ b/Docs/Urho/Subscription.xml
@@ -1,6 +1,6 @@
 <Type Name="Subscription" FullName="Urho.Subscription">
-  <TypeSignature Language="C#" Value="public class Subscription" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Subscription extends System.Object" />
+  <TypeSignature Language="C#" Value="public class Subscription : System.IDisposable" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Subscription extends System.Object implements class System.IDisposable" />
   <AssemblyInfo>
     <AssemblyName>Urho</AssemblyName>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -8,10 +8,14 @@
   <Base>
     <BaseTypeName>System.Object</BaseTypeName>
   </Base>
-  <Interfaces />
+  <Interfaces>
+    <Interface>
+      <InterfaceName>System.IDisposable</InterfaceName>
+    </Interface>
+  </Interfaces>
   <Docs>
-    <summary>Encapsulates the subscription to an event, the main use it to stop event delivery by unsubscribing.</summary>
-    <remarks>Instances of Subscription are returned from the various Subscribe methods exposed by the UrhoObject class.   When you want to stop receiving notifications for a subscription, invoke the <see cref="M:Urho.Subscription.Unsubscribe" /> method.</remarks>
+    <summary>Encapsulates the subscription to an event, the main use is to stop event delivery by unsubscribing or disposing.</summary>
+    <remarks>Instances of Subscription are returned from the various Subscribe methods exposed by the UrhoObject class.   When you want to stop receiving notifications for a subscription, invoke the <see cref="M:Urho.Subscription.Unsubscribe" /> method or the <see cref="M:System.IDisposable.Dispose" /> method.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Unsubscribe">


### PR DESCRIPTION
Makes for a more idiomatic usage and aligned with Rx. 
Makes it possible to use a CompositeDisposable from Rx to 
unsubscribe to a bunch of events at the same time.

NOTE: if/when merging, plz squash&merge, since the doc 
added commit doesn't really need to end up being a separate 
commit. Or not, up to you ;)