### PR TITLE
Size of float (single) is always 4 bytes!

### DIFF
--- a/Bindings/Portable/MarshalHelper.cs
+++ b/Bindings/Portable/MarshalHelper.cs
@@ -7,13 +7,8 @@ namespace Urho
 	{
 		public static unsafe float ReadSingle(this IntPtr ptr, int offset = 0)
 		{
-			if (sizeof (IntPtr) == sizeof (int))
-			{
-				var value32 = Marshal.ReadInt32(ptr, offset);
-				return *(float*)&value32;
-			}
-			var value64 = Marshal.ReadInt64(ptr, offset);
-			return (float)*(double*) &value64;
+			var value32 = Marshal.ReadInt32(ptr, offset);
+			return *(float*)&value32;
 		}
 
 		public static float[] ToFloatsArray(this IntPtr ptr, int size)


### PR DESCRIPTION
Because of float treated as double axis reading doesn't work properly on 64-bit architecture. If you need a double reading please create a separate method.