### PR TITLE
Allow android/iOS forms UrhoSurface to be hidden and shown.

### DIFF
--- a/Bindings/Forms/AndroidSurfaceRenderer.cs
+++ b/Bindings/Forms/AndroidSurfaceRenderer.cs
@@ -29,10 +29,15 @@ namespace Urho.Forms
 		static TaskCompletionSource<Application> applicationTaskSource; 
 		static readonly SemaphoreSlim launcherSemaphore = new SemaphoreSlim(1);
 		readonly FrameLayout surfaceViewPlaceholder;
+		static SDLSurface surfaceView;
 
 		public AndroidUrhoSurface(Android.Content.Context context) : base(context)
 		{
 			AddView(surfaceViewPlaceholder = new FrameLayout(Context));
+			if (surfaceView != null) {
+				surfaceView.RemoveFromParent ();
+				surfaceViewPlaceholder.AddView (surfaceView);
+			}
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
@@ -48,9 +53,11 @@ namespace Urho.Forms
 			await launcherSemaphore.WaitAsync();
 			await Urho.Application.StopCurrent();
 			surfaceViewPlaceholder.RemoveAllViews();
+			surfaceView?.Dispose ();
+			surfaceView = null;
 			applicationTaskSource = new TaskCompletionSource<Application>();
 			Urho.Application.Started += UrhoApplicationStarted;
-			var surfaceView = Urho.Droid.UrhoSurface.CreateSurface((Activity)Context, type, options);
+			surfaceView = Urho.Droid.UrhoSurface.CreateSurface((Activity)Context, type, options);
 			surfaceViewPlaceholder.AddView(surfaceView);
 			return await applicationTaskSource.Task;
 		}

--- a/Bindings/Forms/IosSurfaceRenderer.cs
+++ b/Bindings/Forms/IosSurfaceRenderer.cs
@@ -31,6 +31,12 @@ namespace Urho.Forms
 		static Urho.iOS.UrhoSurface surface;
 		static Urho.Application app;
 
+		public IosSurfaceRenderer() {
+			if (surface != null) {
+				this.Add(surface);
+			}
+		}
+
 		internal async Task<Urho.Application> Launcher(Type type, ApplicationOptions options)
 		{
 			await launcherSemaphore.WaitAsync();


### PR DESCRIPTION
If Forms surfaces are hidden or a another page is placed in front of them, the Urho Application keeps running but the graphics surface is never added back to the view tree. As that surface is static, i simply add it to the view is it already exists when the surface renderer creates the view.