### PR TITLE
tweak some for loops so the JIT will skip array bounds checking

### DIFF
--- a/Bindings/Portable/MarshalHelper.cs
+++ b/Bindings/Portable/MarshalHelper.cs
@@ -38,7 +38,7 @@ namespace Urho
 
 			T[] result = new T[size];
 			var typeSize = Marshal.SizeOf(typeof(T));
-			for (int i = 0; i < size; i++)
+			for (int i = 0; i < result.Length; i++)
 			{
 				IntPtr data = new IntPtr(ptr.ToInt64() + typeSize * i);
 				result[i] = (T)Marshal.PtrToStructure(data, typeof(T));

--- a/Bindings/Portable/NavigationMesh.cs
+++ b/Bindings/Portable/NavigationMesh.cs
@@ -19,7 +19,7 @@ namespace Urho.Navigation
 			var res = new Vector3[count];
 
 			int structSize = Marshal.SizeOf(typeof(Vector3));
-			for (int i = 0; i < count; i++)
+			for (int i = 0; i < res.Length; i++)
 			{
 				IntPtr data = new IntPtr(ptr.ToInt64() + structSize * i);
 				Vector3 item = (Vector3)Marshal.PtrToStructure(data, typeof(Vector3));

--- a/Bindings/Portable/Node.cs
+++ b/Bindings/Portable/Node.cs
@@ -36,7 +36,7 @@ namespace Urho {
 				return ZeroArray;
 			
 			var res = new Node[count];
-			for (int i = 0; i < count; i++){
+			for (int i = 0; i < res.Length; i++){
 				var node = Marshal.ReadIntPtr(ptr, i * IntPtr.Size);
 				res [i] = Runtime.LookupObject<Node> (node);
 			}
@@ -55,7 +55,7 @@ namespace Urho {
 				return ZeroArray;
 			
 			var res = new Node[count];
-			for (int i = 0; i < count; i++){
+			for (int i = 0; i < res.Length; i++){
 				var node = Marshal.ReadIntPtr(ptr, i * IntPtr.Size);
 				res [i] = Runtime.LookupObject<Node> (node);
 			}

--- a/Bindings/Portable/Octree.cs
+++ b/Bindings/Portable/Octree.cs
@@ -12,15 +12,15 @@ namespace Urho
 		List<RayQueryResult> Raycast(Ray ray, RayQueryLevel level, float maxDistance, DrawableFlags drawableFlags, bool single, uint viewMask = UInt32.MaxValue)
 		{
 			Runtime.ValidateRefCounted(this);
-			List<RayQueryResult> result = new List<RayQueryResult>();
 
 			int count;
 			var ptr = Octree_Raycast(Handle, ref ray, ref level, maxDistance, (uint)drawableFlags, viewMask, single, out count);
 
 			if (ptr == IntPtr.Zero)
-				return result;
+				return new List<RayQueryResult>(0);
 
-			int structSize = Marshal.SizeOf(typeof (RayQueryResult));
+            List<RayQueryResult> result = new List<RayQueryResult>(count);
+            int structSize = Marshal.SizeOf(typeof (RayQueryResult));
 			for (int i = 0; i < count; i++)
 			{
 				IntPtr data = new IntPtr(ptr.ToInt64() + structSize * i);

--- a/Bindings/Portable/RenderPath.cs
+++ b/Bindings/Portable/RenderPath.cs
@@ -8,7 +8,7 @@
 			{
 				var count = NumCommands;
 				var result = new RenderPathCommand*[count];
-				for (uint i = 0; i < count; i++)
+				for (uint i = 0; i < result.Length; i++)
 				{
 					result[i] = GetCommand(i);
 				}

--- a/Bindings/Portable/SharpReality/PlaneFinding.cs
+++ b/Bindings/Portable/SharpReality/PlaneFinding.cs
@@ -395,7 +395,7 @@ namespace Urho.SharpReality.HoloToolkit
 			int structsize = Marshal.SizeOf(typeof(BoundedPlane));
 #pragma warning restore 618
 			IntPtr current = outArray;
-			for (int i = 0; i < size; i++)
+			for (int i = 0; i < resArray.Length; i++)
 			{
 #pragma warning disable 618
 				resArray[i] = (BoundedPlane)Marshal.PtrToStructure(current, typeof(BoundedPlane));

--- a/Bindings/SharpReality/SpatialMappingManager.cs
+++ b/Bindings/SharpReality/SpatialMappingManager.cs
@@ -123,7 +123,7 @@ namespace Urho
 			var trianglesBytes = mesh.TriangleIndices.Data.ToArray();
 			var indeces = new short[mesh.TriangleIndices.ElementCount];
 			int indexOffset = 0;
-			for (int i = 0; i < mesh.TriangleIndices.ElementCount; i++)
+			for (int i = 0; i < indeces.Length; i++)
 			{
 				//DirectXPixelFormat.R16UInt
 				var index = BitConverter.ToInt16(trianglesBytes, indexOffset);
@@ -152,7 +152,7 @@ namespace Urho
 			const int normalStride = 16; // (int) mesh.VertexNormals.Stride;
 
 			//2,3 - VertexPositions and Normals
-			for (int i = 0; i < vertexCount; i++)
+			for (int i = 0; i < vertexData.Length; i++)
 			{
 				var positionX = BitConverter.ToSingle(vertexRawData, i * vertexStride + 0); 
 				var positionY = BitConverter.ToSingle(vertexRawData, i * vertexStride + 4); //4 per X,Y,Z,W (stride is 16)


### PR DESCRIPTION
This PR simply adjusts from ``for`` loops in the codebase to use array Length method when possible.  When structured this way, the JIT'd code will have some array bounds-checks removed, resulting in faster execution.