### PR TITLE
[RotateTo] Initialize with Euler angles

### DIFF
--- a/Bindings/Portable/Actions/Intervals/RotateTo.cs
+++ b/Bindings/Portable/Actions/Intervals/RotateTo.cs
@@ -54,7 +54,7 @@ namespace Urho.Actions
 			DistanceAngleY = action.DistanceAngleY;
 			DistanceAngleZ = action.DistanceAngleZ;
 
-			var sourceRotation = Target.Rotation;
+			var sourceRotation = Target.Rotation.ToEulerAngles();
 
 			// Calculate X
 			StartAngleX = sourceRotation.X;


### PR DESCRIPTION
Angles in RotateTo should be initialized with current Euler angles, not with the quaternion components.