### PR TITLE
fix bounding box growth, and rotate normals too

### DIFF
--- a/Bindings/Portable/SharpReality/StereoApplication.cs
+++ b/Bindings/Portable/SharpReality/StereoApplication.cs
@@ -231,7 +231,7 @@ namespace Urho.SharpReality
 		/// </summary>
 		public virtual Model GenerateModelFromSpatialSurface(SpatialMeshInfo surface)
 		{
-			return CreateModelFromVertexData(surface.VertexData, surface.IndexData);
+			return CreateModelFromVertexData(surface.VertexData, surface.IndexData, surface.BoundsRotation);
 		}
 
 		internal void HandleSurfaceUpdated(SpatialMeshInfo surface)

--- a/Bindings/Portable/SharpReality/StereoApplication.cs
+++ b/Bindings/Portable/SharpReality/StereoApplication.cs
@@ -258,7 +258,10 @@ namespace Urho.SharpReality
 				{
 					var position = rotation * vertexData[i].Position;
 					vertexData[i].Position = position;
-					boundingBox.Merge(boundingBox);
+					boundingBox.Merge(position);
+
+					var normal = rotation * vertexData[i].Normal;
+					vertexData[i].Normal = normal;
 				}
 			}
 			else


### PR DESCRIPTION
In cases where SteroApplication.CreateModelFromVertexData was called with a rotation value, the bounding box was not being grown and normals weren't being rotated with the position.