### PR TITLE
Fix to P0001 in ARCore Shader

### DIFF
--- a/Urho3D/CoreData/Shaders/GLSL/ARCore.glsl
+++ b/Urho3D/CoreData/Shaders/GLSL/ARCore.glsl
@@ -1,9 +1,9 @@
+#extension GL_OES_EGL_image_external : require
+
 #include "Uniforms.glsl"
 #include "Samplers.glsl"
 #include "Transform.glsl"
 #include "ScreenPos.glsl"
-
-#extension GL_OES_EGL_image_external : require
 
 varying highp vec2 vScreenPos;
 uniform float cCameraScale;


### PR DESCRIPTION
Fix to:
Failed to compile vertex shader ARCore():
0:593: P0001: Extension directive must occur before any non-preprocessor tokens