### PR TITLE
[Hololens] Calculate appropriate culling camera frustum and position.

### DIFF
--- a/Bindings/Portable/SharpReality/StereoApplication.cs
+++ b/Bindings/Portable/SharpReality/StereoApplication.cs
@@ -135,7 +135,8 @@ namespace Urho.SharpReality
 			Renderer.SetViewport(0, leftViewport);
 			Renderer.SetViewport(1, rightVp);
 
-			CullingCamera = leftCameraNode.CreateComponent<Camera>();
+			var cullingCameraNode = Scene.CreateChild();
+			CullingCamera = cullingCameraNode.CreateComponent<Camera>();
 			rightVp.CullCamera = CullingCamera;
 			leftViewport.CullCamera = CullingCamera;
 			rightVp.SetStereoMode(true);


### PR DESCRIPTION
Previously, the left eye was used for culling, but with an expanded FOV. This change calculates the culling camera's position such that its frustum matches the extent of the combined frusta of both the left and right eyes.

See [this post](https://www.facebook.com/photo.php?fbid=10154006919426632&set=a.46932936631.70217.703211631&type=3&theater) for details of the approach.